### PR TITLE
Adding missing unit on label height.

### DIFF
--- a/sass/skyblue/_forms.scss
+++ b/sass/skyblue/_forms.scss
@@ -73,7 +73,7 @@ select{
 label{
 	display: block;
 	margin-bottom: 0.5em;
-	height: 1.5;
+	height: 1.5em;
 	line-height: 1.5em;
 
 	&.error, .error &{


### PR DESCRIPTION
Just a minor thing: without units the property is ignored in webkit but gecko applies pixels, so things look weird.
